### PR TITLE
PEP8 refactor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,3 @@ django = "==1.11.17"
 pytz = "*"
 django-crispy-forms = "*"
 djangorestframework = "*"
-
-[requires]
-python_version = "3.7"

--- a/marcador/urls.py
+++ b/marcador/urls.py
@@ -1,13 +1,26 @@
 from django.conf.urls import url
+
 from . import views
 
 urlpatterns = [
-url(r'^user/(?P<username>[-\w]+)/$', views.bookmark_user,
-name='marcador_bookmark_user'),
-
-url(r'^create/$', views.bookmark_create,
-        name='marcador_bookmark_create'),
-url(r'^edit/(?P<pk>\d+)/$', views.bookmark_edit,
-        name='marcador_bookmark_edit'),
-url(r'^$', views.bookmark_list, name='marcador_bookmark_list'),
+    url(
+        r'^user/(?P<username>[-\w]+)/$',
+        views.bookmark_user,
+        name='marcador_bookmark_user'
+    ),
+    url(
+        r'^create/$',
+        views.bookmark_create,
+        name='marcador_bookmark_create'
+    ),
+    url(
+        r'^edit/(?P<pk>\d+)/$',
+        views.bookmark_edit,
+        name='marcador_bookmark_edit'
+    ),
+    url(
+        r'^$',
+        views.bookmark_list,
+        name='marcador_bookmark_list'
+    ),
 ]


### PR DESCRIPTION
We have to keep proper white space between the imports:

- first come Python built-in libraries
- second third-party Python pacakges
- third Django modules
- fourth third-party Django packages, for exampl Django REST Framework
- fifth our own modules

All should be separated by one empty white line. Example:

    import sys

    import requests

    from django.conf.urls import url

    from rest_framework import generics

    from . import views

I changed the indentation of the `urls` too.