### PR TITLE
Create NestedBookmarkSerializer

### DIFF
--- a/.idea/marcador.iml
+++ b/.idea/marcador.iml
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="django" name="Django">
+      <configuration>
+        <option name="rootFolder" value="$MODULE_DIR$" />
+        <option name="settingsModule" value="mysite/settings.py" />
+        <option name="manageScript" value="manage.py" />
+        <option name="environment" value="&lt;map/&gt;" />
+        <option name="doNotUseTestRunner" value="false" />
+        <option name="trackFilePattern" value="" />
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="jdk" jdkName="Pipenv (Marcador)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Django" />
   </component>
 </module>

--- a/marcador/serializers.py
+++ b/marcador/serializers.py
@@ -28,8 +28,17 @@ class TagSerializer(serializers.HyperlinkedModelSerializer):
         fields = ['url', 'id', 'name']
 
 
+class NestedBookmarkSerializer(serializers.HyperlinkedModelSerializer):
+    tags = TagSerializer(many=True)
+
+    class Meta:
+        model = Bookmark
+        fields = ['url', 'id', 'bookmark_url', 'title', 'description', 'is_public',
+                  'date_created', 'date_updated', 'tags']
+
+
 class UserSerializer(serializers.HyperlinkedModelSerializer):
-    bookmarks = BookmarkSerializer(many=True)
+    bookmarks = NestedBookmarkSerializer(many=True)
 
     class Meta:
         model = User


### PR DESCRIPTION
One new serializer was added: **NestedBookmarkSerializer**.

The endpoint *users* uses this serializer.  
Use this serializer inside the method `bookmarks` for the custom route `user-bookmarks` (*/api/users/\<username\>/bookmarks/*).